### PR TITLE
Add refresh token endpoint to issue new access tokens

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
-import { register, login } from '../controllers/authController';
+import { register, login, refresh } from '../controllers/authController';
 import { authenticateToken } from '../middleware/auth';
 
 const router = Router();
 
 router.post('/register', register);
 router.post('/login', login);
+router.post('/refresh', refresh);
 
 // Protected route example
 router.get('/profile', authenticateToken, (req, res) => {


### PR DESCRIPTION
This PR adds a refresh token endpoint to securely renew access tokens without requiring users to re-authenticate.

### Key Changes
- Refresh Endpoint: Added POST /auth/refresh that accepts a valid refresh token
- Token Renewal: Verifies refresh token, finds user, and issues new access (15m) and refresh (7d) tokens
- Security: Old refresh tokens are effectively invalidated by issuing new ones

### Features
- Validates refresh token integrity and expiration
- Returns new token pair on success
- Proper error handling for invalid/expired tokens

### Usage
```
POST /auth/refresh
{
  "refreshToken": "your_refresh_token_here"
}
```

This enhances security by allowing short-lived access tokens while providing a seamless user experience through automatic token renewal.